### PR TITLE
Backport Ruby functionality for technical debt purposes

### DIFF
--- a/lib/puppet/functions/length.rb
+++ b/lib/puppet/functions/length.rb
@@ -1,0 +1,18 @@
+#######################################################
+## This is a backport from puppetlabs-stdlib v4.16.0 ##
+##           Backport reason: We run v4.10           ##
+#######################################################
+#A function to eventually replace the old size() function for stdlib - The original size function did not handle Puppets new type capabilities, so this function is a Puppet 4 compatible solution. 
+Puppet::Functions.create_function(:length) do
+  dispatch :length do
+    param 'Variant[String,Array,Hash]', :value
+  end
+  def	length(value)
+    if value.is_a?(String)
+      result = value.length
+    elsif value.is_a?(Array) || value.is_a?(Hash)
+      result = value.size
+    end
+    return result
+  end
+end

--- a/lib/puppet/type/grafana_dashboard.rb
+++ b/lib/puppet/type/grafana_dashboard.rb
@@ -24,7 +24,8 @@ Puppet::Type.newtype(:grafana_dashboard) do
 
     munge do |value|
       new_value = JSON.parse(value).reject { |k, _| k =~ %r{^id|version|title$} }
-      new_value.sort.to_h
+      # This is a fix for the missing to_h method introduced in Ruby 2.1.0
+      Hash[new_value.map {|key, value| [key, value]}]
     end
 
     def should_to_s(value)

--- a/lib/puppet/type/grafana_dashboard.rb
+++ b/lib/puppet/type/grafana_dashboard.rb
@@ -25,6 +25,7 @@ Puppet::Type.newtype(:grafana_dashboard) do
     munge do |value|
       new_value = JSON.parse(value).reject { |k, _| k =~ %r{^id|version|title$} }
       # This is a fix for the missing to_h method introduced in Ruby 2.1.0
+      # https://stackoverflow.com/a/9571767
       Hash[new_value.map {|key, value| [key, value]}]
     end
 


### PR DESCRIPTION
- workaround to missing `to_h` method in Ruby 1.9.3
- backport `length` function from `puppetlabs-stdlib` (introduced in v4.16) for older versions of `stdlib`